### PR TITLE
Add support native snap building on Ubuntu 18.04

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: "An office suite that allowing to create, view and edit local documents
 description: "ONLYOFFICE Desktop Editors is a free office suite that combines text, spreadsheet and presentation editors allowing to create, view and edit documents stored on your Windows/Linux PC or Mac without an Internet connection. It is fully compatible with Office Open XML formats: .docx, .xlsx, .pptx."
 grade: stable
 confinement: strict
+base: core18
 icon: icons/asc-de-256.png
 architectures:
   - amd64
@@ -46,7 +47,6 @@ parts:
         - libcomerr2
         - libcurl3
         - libcurl3-gnutls
-        - libdouble-conversion1v5
         - libflac8
         - libgail-3-0
         - libgcc1
@@ -58,7 +58,6 @@ parts:
         - libgstreamer-plugins-base1.0-0
         - libgstreamer1.0-0
         - libgtkglext1
-        - libjasper1
         - liblzma5
         - libnss3
         - liborc-0.4-0


### PR DESCRIPTION
Changed a snap of type base to be used as the execution environment for this snap.