### PR TITLE
Add common-id

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,6 +29,7 @@ plugs:
 apps:
   onlyoffice-desktopeditors:
     command: usr/bin/desktopeditors
+    common-id: org.onlyoffice.desktopeditors
     extensions:
       - gnome-3-38
     desktop: usr/share/applications/onlyoffice-desktopeditors.desktop


### PR DESCRIPTION
See https://forum.snapcraft.io/t/support-for-appstream-id/2327
Currently GNOME Software will show two separate entries for the Flatpak and Snap.

Use same id as Flatpak: https://flathub.org/apps/details/org.onlyoffice.desktopeditors